### PR TITLE
fix: temporarely add sprockets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-#require "sprockets/railtie"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
This doesn't really fix the issue. 
Indeed, the bug has to be fixed in the https://github.com/hotwired/stimulus-rails package.

This workaround adds sprockets to your app (if that's possible for your scenario). With this workaround you can start upgrading your Avo to v 1.0+